### PR TITLE
Disable forms by default

### DIFF
--- a/src/knative.ts
+++ b/src/knative.ts
@@ -82,6 +82,14 @@ export default class MyPlugin implements octant.Plugin {
     this.linker = (ref: V1ObjectReference, context?: V1ObjectReference) => knativeLinker(this.dashboardClient.RefPath, ref, context);
 
     this.router.add([{
+      path: "/_create",
+      handler: (params: any) => {
+        this.create = true;
+        this.dashboardClient.SendEvent(params.clientID, "event.octant.dev/contentPath", { contentPath: "/knative" });
+        return h.createContentResponse([], []);
+      }
+    }]);
+    this.router.add([{
       path: "/serving",
       handler: this.servingOverviewHandler,
     }]);

--- a/src/knative.ts
+++ b/src/knative.ts
@@ -45,6 +45,8 @@ export default class MyPlugin implements octant.Plugin {
   // If true, the contentHandler and navigationHandler will be called.
   isModule = true;
 
+  create = false;
+
   // Octant will assign these via the constructor at runtime.
   dashboardClient: DashboardClient;
   httpClient: octant.HTTPClient;
@@ -528,7 +530,7 @@ export default class MyPlugin implements octant.Plugin {
     });
     services.sort((a, b) => (a.metadata.name || '').localeCompare(b.metadata.name || ''));
 
-    const buttonGroup = new ButtonGroupFactory({
+    const buttonGroup = this.create ? new ButtonGroupFactory({
       buttons: [
         {
           name: "New Service",
@@ -540,7 +542,7 @@ export default class MyPlugin implements octant.Plugin {
         },
       ],
       factoryMetadata,
-    });
+    }) : void 0;
 
     return new ServiceListFactory({ services, buttonGroup, linker: this.linker, factoryMetadata });
   }
@@ -604,6 +606,7 @@ export default class MyPlugin implements octant.Plugin {
           title: [new TextFactory({ value: "Summary" }).toComponent()],
           accessor: "summary",
         },
+        create: this.create,
       }),
       new MetadataSummaryFactory({
         object: service,
@@ -705,6 +708,7 @@ export default class MyPlugin implements octant.Plugin {
           title: [new TextFactory({ value: "Summary" }).toComponent()],
           accessor: "summary",
         },
+        create: this.create,
       }),
       new MetadataSummaryFactory({
         object: configuration,

--- a/src/serving/configuration.ts
+++ b/src/serving/configuration.ts
@@ -122,6 +122,7 @@ interface ConfigurationDetailParameters {
   childDeployments?: {[key: string]: V1Deployment};
   linker: (ref: V1ObjectReference, context?: V1ObjectReference) => string;
   factoryMetadata?: FactoryMetadata;
+  create?: boolean;
 }
 
 export class ConfigurationSummaryFactory implements ComponentFactory<any> {
@@ -130,13 +131,15 @@ export class ConfigurationSummaryFactory implements ComponentFactory<any> {
   private readonly childDeployments?: {[key: string]: V1Deployment};
   private readonly linker: (ref: V1ObjectReference, context?: V1ObjectReference) => string;
   private readonly factoryMetadata?: FactoryMetadata;
+  private readonly create?: boolean;
 
-  constructor({ configuration, revisions, childDeployments, linker, factoryMetadata }: ConfigurationDetailParameters) {
+  constructor({ configuration, revisions, childDeployments, linker, factoryMetadata, create }: ConfigurationDetailParameters) {
     this.configuration = configuration;
     this.revisions = revisions;
     this.childDeployments = childDeployments;
     this.linker = linker;
     this.factoryMetadata = factoryMetadata;
+    this.create = create;
   }
   
   toComponent(): Component<any> {
@@ -160,7 +163,7 @@ export class ConfigurationSummaryFactory implements ComponentFactory<any> {
     const container = spec.template.spec?.containers[0];
 
     const actions = [];
-    if (!(metadata.ownerReferences || []).some(r => r.controller)) {
+    if (this.create && !(metadata.ownerReferences || []).some(r => r.controller)) {
       // only allow for non-controlled resources
       actions.push(configureAction(this.configuration));
     }

--- a/src/serving/service.ts
+++ b/src/serving/service.ts
@@ -93,6 +93,11 @@ export class NewServiceFactory implements ComponentFactory<any> {
                   name: "name",
                   value: "",
                   label: "Name",
+                  placeholder: "my-service",
+                  error: "Service name is required.",
+                  validators: [
+                    "required"
+                  ],
                   configuration: {},
                 },
                 {
@@ -100,6 +105,7 @@ export class NewServiceFactory implements ComponentFactory<any> {
                   name: "revisionName",
                   value: "",
                   label: "Revision Name",
+                  placeholder: "v2",
                   configuration: {},
                 },
                 {
@@ -107,6 +113,11 @@ export class NewServiceFactory implements ComponentFactory<any> {
                   name: "image",
                   value: "",
                   label: "Image",
+                  placeholder: "docker.io/example/app",
+                  error: "Image name is required.",
+                  validators: [
+                    "required"
+                  ],
                   configuration: {},
                 },
               ],
@@ -215,6 +226,7 @@ interface ServiceDetailParameters {
   childDeployments?: {[key: string]: V1Deployment};
   linker: (ref: V1ObjectReference, context?: V1ObjectReference) => string;
   factoryMetadata?: FactoryMetadata;
+  create?: boolean;
 }
 
 export class ServiceSummaryFactory implements ComponentFactory<any> {
@@ -223,13 +235,15 @@ export class ServiceSummaryFactory implements ComponentFactory<any> {
   private readonly childDeployments?: {[key: string]: V1Deployment};
   private readonly linker: (ref: V1ObjectReference, context?: V1ObjectReference) => string;
   private readonly factoryMetadata?: FactoryMetadata;
+  private readonly create?: boolean;
 
-  constructor({ service, revisions, childDeployments, linker, factoryMetadata }: ServiceDetailParameters) {
+  constructor({ service, revisions, childDeployments, linker, factoryMetadata, create }: ServiceDetailParameters) {
     this.service = service;
     this.revisions = revisions;
     this.childDeployments = childDeployments;
     this.linker = linker;
     this.factoryMetadata = factoryMetadata;
+    this.create = create;
   }
   
   toComponent(): Component<any> {
@@ -253,7 +267,7 @@ export class ServiceSummaryFactory implements ComponentFactory<any> {
     const container = spec.template.spec?.containers[0];
 
     const actions = [];
-    if (!(metadata.ownerReferences || []).some(r => r.controller)) {
+    if (this.create && !(metadata.ownerReferences || []).some(r => r.controller)) {
       // only allow for non-controlled resources
       actions.push(configureAction(this.service));
     }


### PR DESCRIPTION
Octant's support for custom forms is quite immature and doesn't provide
a good user experience. We should disable this feature until Octant has
better support built-in.

Users can still delete resources, edit resource yaml, or create new resources by applying yaml.