### PR TITLE
Migrate new service page into a modal

### DIFF
--- a/src/knative.ts
+++ b/src/knative.ts
@@ -29,7 +29,6 @@ import {
   configurationListingContentHandler,
   configureActionHandler,
   newServiceActionHandler,
-  newServiceContentHandler,
   revisionDetailContentHandler,
   revisionListContentHandler,
   routeDetailContentHandler,
@@ -86,7 +85,6 @@ export default class KnativePlugin implements octant.Plugin {
     }]);
     this.router.add([{ path: "/serving", handler: servingOverviewContentHandler }]);
     this.router.add([{ path: "/serving/services", handler: serviceListingContentHandler }]);
-    this.router.add([{ path: "/serving/services/_new", handler: newServiceContentHandler }]);
     this.router.add([{ path: "/serving/services/:serviceName", handler: serviceDetailContentHandler }]);
     this.router.add([{ path: "/serving/services/:serviceName/revisions", handler: revisionListContentHandler }]);
     this.router.add([{ path: "/serving/services/:serviceName/revisions/:revisionName", handler: revisionDetailContentHandler }]);

--- a/src/serving.ts
+++ b/src/serving.ts
@@ -122,18 +122,6 @@ export function serviceListingContentHandler(params: any): octant.ContentRespons
   return h.createContentResponse(title, [body]);
 }
 
-// form to create a new service
-export function newServiceContentHandler(params: any): octant.ContentResponse {
-  const title = [
-    new LinkFactory({ value: "Knative", ref: "/knative" }),
-    new LinkFactory({ value: "Serving", ref: ctx.linker({ apiVersion: ServingV1 }) }),
-    new LinkFactory({ value: "Services", ref: ctx.linker({ apiVersion: ServingV1, kind: ServingV1Service }) }),
-    new TextFactory({ value: "New Service" }),
-  ];
-  const body = newService(params.clientID, { title: title.map(c => c.toComponent()) });
-  return h.createContentResponse(title, body);
-}
-
 export function serviceDetailContentHandler(params: any): octant.ContentResponse {
   const name: string = params.serviceName;
   const service: Service = ctx.dashboardClient.Get({
@@ -366,23 +354,14 @@ export function serviceListing(clientID: string, factoryMetadata?: FactoryMetada
     buttons: [
       {
         name: "New Service",
-        payload: {
-          action: "knative.dev/setContentPath",
-          clientID: clientID,
-          contentPath: ctx.linker({ apiVersion: ServingV1, kind: ServingV1Service, name: "_new" }),
-        },
+        payload: {},
+        modal: new NewServiceFactory({ clientID }).toComponent(),
       },
     ],
     factoryMetadata,
   }) : void 0;
 
   return new ServiceListFactory({ services, buttonGroup, factoryMetadata });
-}
-
-export function newService(clientID: string, factoryMetadata?: FactoryMetadata ): ComponentFactory<any>[] {
-  const form = new NewServiceFactory({ clientID, factoryMetadata });
-  
-  return [form];
 }
 
 export function serviceDetail(service: Service): ComponentFactory<any>[] {

--- a/src/serving/service.ts
+++ b/src/serving/service.ts
@@ -18,7 +18,7 @@ import { FlexLayoutFactory } from "@project-octant/plugin/components/flexlayout"
 import { GridActionsFactory } from "@project-octant/plugin/components/grid-actions";
 import { deleteGridAction } from "../components/grid-actions";
 import { LinkFactory } from "@project-octant/plugin/components/link";
-import { ListFactory } from "@project-octant/plugin/components/list";
+import { ModalFactory } from "@project-octant/plugin/components/modal";
 import { containerPorts, environmentList, volumeMountList } from "../components/pod";
 import { KnativeResourceViewerFactory, ResourceViewerConfig, Node, Edge } from "../components/resource-viewer";
 import { SummaryFactory } from "@project-octant/plugin/components/summary";
@@ -46,74 +46,65 @@ export class NewServiceFactory implements ComponentFactory<any> {
 
   constructor({ clientID, factoryMetadata }: NewServiceParameters) {
     this.clientID = clientID;
-    this.factoryMetadata = factoryMetadata;
+    this.factoryMetadata = factoryMetadata || {
+      title: [
+        new TextFactory({ value: "New Service" }).toComponent(),
+      ],
+    };
   }
   
   toComponent(): Component<any> {
-    // TODO hack to render a form, any form. Replace with something real
-    const form = new SummaryFactory({
-      sections: [],
+    const modal = new ModalFactory({
+      opened: false,
+      factoryMetadata: this.factoryMetadata,
       options: {
-        actions: [
-          {
-            name: "Configure",
-            title: "Create Service",
-            form: {
-              fields: [
-                {
-                  type: "hidden",
-                  name: "action",
-                  value: "knative.dev/newService",
-                },
-                {
-                  type: "hidden",
-                  name: "clientID",
-                  value: this.clientID,
-                },
-                {
-                  type: "text",
-                  name: "name",
-                  value: "",
-                  label: "Name",
-                  placeholder: "my-service",
-                  error: "Service name is required.",
-                  validators: [
-                    "required"
-                  ],
-                  configuration: {},
-                },
-                {
-                  type: "text",
-                  name: "revisionName",
-                  value: "",
-                  label: "Revision Name",
-                  placeholder: "v2",
-                  configuration: {},
-                },
-                {
-                  type: "text",
-                  name: "image",
-                  value: "",
-                  label: "Image",
-                  placeholder: "docker.io/example/app",
-                  error: "Image name is required.",
-                  validators: [
-                    "required"
-                  ],
-                  configuration: {},
-                },
-              ],
+        body: new TextFactory({ value: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." }).toComponent(),
+        form: {
+          action: "knative.dev/newService",
+          fields: [
+            {
+              type: "hidden",
+              name: "clientID",
+              value: this.clientID,
             },
-            modal: false,
-          },
-        ],
+            {
+              type: "text",
+              name: "name",
+              value: "",
+              label: "Name",
+              placeholder: "my-service",
+              error: "Service name is required.",
+              validators: [
+                "required"
+              ],
+              configuration: {},
+            },
+            {
+              type: "text",
+              name: "revisionName",
+              value: "",
+              label: "Revision Name",
+              placeholder: "v2",
+              configuration: {},
+            },
+            {
+              type: "text",
+              name: "image",
+              value: "",
+              label: "Image",
+              placeholder: "docker.io/example/app",
+              error: "Image name is required.",
+              validators: [
+                "required"
+              ],
+              configuration: {},
+            },
+          ],
+        },
       },
     });
-    const layout = new ListFactory({
-      items: [form.toComponent()],
-      factoryMetadata: this.factoryMetadata,
-    });
-    return layout.toComponent();
+
+    return modal.toComponent();
   }
 }
 

--- a/src/serving/service.ts
+++ b/src/serving/service.ts
@@ -58,7 +58,7 @@ export class NewServiceFactory implements ComponentFactory<any> {
       opened: false,
       factoryMetadata: this.factoryMetadata,
       options: {
-        body: new TextFactory({ value: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." }).toComponent(),
+        body: new TextFactory({ value: "To create a service using a container image, specify the name of the service and the image. Naming the revision is optional." }).toComponent(),
         form: {
           action: "knative.dev/newService",
           fields: [


### PR DESCRIPTION
Removing /knative/serving/services/_new page

<img width="608" alt="Screen Shot 2020-11-01 at 10 05 30 PM" src="https://user-images.githubusercontent.com/302992/97826036-84919800-1c8e-11eb-8be0-23dec38ac5ff.png">

Resolves #45